### PR TITLE
fix source RB issue

### DIFF
--- a/pmml-xgboost-example/pom.xml
+++ b/pmml-xgboost-example/pom.xml
@@ -23,10 +23,6 @@
 		</license>
 	</licenses>
 
-	<properties>
-		<project.build.outputTimestamp>2024-04-29T20:13:19Z</project.build.outputTimestamp>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.jpmml</groupId>

--- a/pmml-xgboost/pom.xml
+++ b/pmml-xgboost/pom.xml
@@ -23,10 +23,6 @@
 		</license>
 	</licenses>
 
-	<properties>
-		<project.build.outputTimestamp>2024-04-29T20:13:19Z</project.build.outputTimestamp>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.jpmml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 				<configuration>


### PR DESCRIPTION
see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/jpmml/jpmml-xgboost/README.md
release rrequires a recent maven-source-plugin version
while at it, dropping not necessary timestamps: root one is sufficient

check with `mvn artifact:check-buildplan -Psonatype-oss-release`